### PR TITLE
feat(button): support plain button text color token

### DIFF
--- a/.cursor/skills/demo-i18n-workflow/SKILL.md
+++ b/.cursor/skills/demo-i18n-workflow/SKILL.md
@@ -28,7 +28,8 @@ description: Adds or updates component demo, I18n (example/i18n/strings.json), a
 - **版本号**：仅 README/README.en 需要带版本号，strings.json 不需要。
   - **新增 demo 区块**：该 demo 的标题后面加空格和版本号，例如：`### 文字颜色 \`v2.10.0\``。
   - **API/Props 表格新增属性或参数**：在该行「说明」列末尾或参数名列后加版本号，例如：`| my-text-color \`v2.11.0\` | 按钮文字颜色 | _string_ | - |`。
-  - 版本号以当前开发版本为准（可从项目根目录 `package.json` 的 `version` 获取，或询问用户）。
+  - 版本号以当前对外正式版本为准（可从项目根目录 `package.json` 的 `version` 获取主版本号）。
+  - 如果 `package.json` 中的版本带有预发布后缀，如 `2.13.2-beta-0`、`2.13.2-rc.1`，README/README.en 中只写正式版本号部分：`v2.13.2`。
 
 ## 流程
 
@@ -42,5 +43,5 @@ description: Adds or updates component demo, I18n (example/i18n/strings.json), a
 - [ ] Demo 中无硬编码中文/英文，均通过 I18n.t('key') 展示
 - [ ] 所用 key 在 strings.json 的 en、zh 中均有对应文案
 - [ ] 所有 README 内 demo 的标题以及内容均和 `packages/<组件名>/demo/` 内代码一一对应
-- [ ] **新增 demo 或新增 API 属性时**：README/README.en 中已为新增 demo 标题、新增 API 行补充版本号
+- [ ] **新增 demo 或新增 API 属性时**：README/README.en 中已为新增 demo 标题、新增 API 行补充正式版本号，且不带 `-beta-0` 等预发布后缀
 - [ ] `yarn test` 通过，必要时已更新快照

--- a/packages/button/README.en.md
+++ b/packages/button/README.en.md
@@ -34,9 +34,10 @@ Supports five types: `default`, `primary`, `info`, `warning`, and `danger`. Defa
 
 ### Plain Button
 
-Set the button as plain using the `plain` attribute. The text is the button color, and the background is white.
+Set the button to a plain style using the `plain` attribute, where the text color of the plain button matches the button color; the default background is white, and the font color is black.
 
 ```html
+<smart-button plain>Plain Button</smart-button>
 <smart-button plain type="primary">Plain Button</smart-button>
 <smart-button plain type="info">Plain Button</smart-button>
 ```
@@ -197,6 +198,7 @@ The component provides the following CSS variables that can be used for custom s
 | --button-border-width                         | _1px_                                          | Button border width                   |
 | --button-border-radius                        | _10px_                                         | Button border radius                  |
 | --button-round-border-radius                  | _999px_                                        | Round button border radius            |
+| --button-plain-color `v2.13.2`        | _rgba(0, 0, 0, 0.9)_                           | Plain button text color               |
 | --button-plain-background-color               | _#fff_                                         | Plain button background color         |
 | --button-disabled-opacity                     | _0.3_                                          | Disabled button opacity               |
 | --button-font-weight                          | _normal_                                       | Button font weight                    |

--- a/packages/button/README.md
+++ b/packages/button/README.md
@@ -34,9 +34,11 @@ category: 通用
 
 ### 朴素按钮
 
-通过`plain`属性将按钮设置为朴素按钮，朴素按钮的文字为按钮颜色，背景为白色。
+通过`plain`属性将按钮设置为朴素按钮，朴素按钮的文字为按钮颜色；默认背景为白色，字体为黑色。
+
 
 ```html
+<smart-button plain>朴素按钮</smart-button>
 <smart-button plain type="primary">朴素按钮</smart-button>
 <smart-button plain type="info">朴素按钮</smart-button>
 ```
@@ -196,6 +198,7 @@ category: 通用
 | --button-border-width                         | _1px_                                          | 按钮边框宽度                       |
 | --button-border-radius                        | _10px_                                         | 按钮边框圆角半径                   |
 | --button-round-border-radius                  | _999px_                                        | 圆形按钮边框圆角半径               |
+| --button-plain-color `v2.13.2`        | _rgba(0, 0, 0, 0.9)_                           | 纯按钮文字颜色                     |
 | --button-plain-background-color               | _#fff_                                         | 纯按钮背景颜色                     |
 | --button-disabled-opacity                     | _0.3_                                          | 禁用按钮不透明度                   |
 | --button-font-weight                          | _normal_                                       | 按钮字体粗细                       |

--- a/packages/button/demo/index.wxml
+++ b/packages/button/demo/index.wxml
@@ -9,6 +9,9 @@
 </demo-block>
 
 <demo-block title="{{I18n.t('simpleButton')}}" padding>
+  <smart-button plain class="demo-margin-right">
+    {{I18n.t('simpleButton')}}
+  </smart-button>
   <smart-button type="info" plain class="demo-margin-right">{{I18n.t('simpleButton')}}</smart-button>
   <smart-button type="primary" plain>{{I18n.t('simpleButton')}}</smart-button>
 </demo-block>

--- a/packages/button/index.less
+++ b/packages/button/index.less
@@ -115,6 +115,7 @@
   }
 
   &--plain {
+    color: var(--button-plain-color, @button-plain-color);
     background: var(--button-plain-background-color, @button-plain-background-color);
 
     &.smart-button--primary {

--- a/packages/button/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/button/test/__snapshots__/demo.spec.ts.snap
@@ -216,6 +216,47 @@ exports[`should render demo and match snapshot 1`] = `
           appParameter=""
           ariaLabel=""
           businessId="{{0}}"
+          class="custom-class smart-button smart-button--default smart-button--normal smart-button--plain "
+          data-detail="{{null}}"
+          formType=""
+          hoverClass="smart-button--active hover-class"
+          id=""
+          lang=""
+          openType=""
+          sendMessageImg=""
+          sendMessagePath=""
+          sendMessageTitle=""
+          sessionFrom=""
+          showMessageCard="{{false}}"
+          style=""
+          bind:agreeprivacyauthorization="onAgreePrivacyAuthorization"
+          bind:chooseavatar="onChooseAvatar"
+          bind:contact="onContact"
+          bind:error="onError"
+          bind:getphonenumber="onGetPhoneNumber"
+          bind:getrealtimephonenumber="onGetRealTimePhoneNumber"
+          bind:getuserinfo="onGetUserInfo"
+          bind:launchapp="onLaunchApp"
+          bind:opensetting="onOpenSetting"
+          bind:tap="onClick"
+        >
+          <wx-view
+            class="smart-button__text"
+            style=""
+          >
+            
+    
+  
+          </wx-view>
+        </wx-button>
+      </smart-button>
+      <smart-button
+        class="demo-margin-right"
+      >
+        <wx-button
+          appParameter=""
+          ariaLabel=""
+          businessId="{{0}}"
           class="custom-class smart-button smart-button--info smart-button--normal smart-button--plain "
           data-detail="{{null}}"
           formType=""

--- a/packages/common/style/var.less
+++ b/packages/common/style/var.less
@@ -264,6 +264,7 @@
 @button-disabled-opacity: @disabled-opacity;
 @button-font-weight: normal;
 @button-primary-font-weight: 600;
+@button-plain-color: rgba(0, 0, 0, 0.9);
 
 // Calendar
 @calendar-background-color: @B6;


### PR DESCRIPTION
Add a configurable text color token for the default plain button state and sync the button demo/docs. Update the README workflow skill to use public release version tags without prerelease suffixes.